### PR TITLE
Remove _.findWhere in favor of _.find

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -61,7 +61,7 @@ Plex2Netflix.prototype.findSpecificLibraries = function (sections) {
     const sectionResults = [];
     // Try to find all sections.
     this.options.librarySections.forEach((sectionTitle) => {
-        const theSection = _.findWhere(sections, { title: sectionTitle });
+        const theSection = _.find(sections, { title: sectionTitle });
         // If section can't be found, list all sections and exit.
         if (!theSection) {
             const sectionTitles = _.map(sections, 'title');


### PR DESCRIPTION
This seems to work with the newer version of lodash